### PR TITLE
feat: [release-0.1] CORE 0.15用にCUDAとcuDNNのバージョンを上げる

### DIFF
--- a/.github/actions/download-cuda-libraries/action.yml
+++ b/.github/actions/download-cuda-libraries/action.yml
@@ -53,7 +53,7 @@ runs:
         rm -f download/cudnn.*
         mkdir -p ${{ inputs.extract_dir }}
         cp -v docs/licenses/cuda/* "${{ inputs.extract_dir }}"
-    - uses: Jimver/cuda-toolkit@v0.2.8
+    - uses: Jimver/cuda-toolkit@v0.2.15
       id: cuda-toolkit
       with:
         method: network

--- a/.github/actions/download-cuda-libraries/action.yml
+++ b/.github/actions/download-cuda-libraries/action.yml
@@ -17,13 +17,13 @@ runs:
   using: "composite"
   steps:
     - name: Prepare CUDA cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cuda-library-cache
       with:
         key: v1-cuda-library-cache-${{ inputs.asset_name }}-${{ inputs.cuda_version }}
         path: download/cuda
     - name: Prepare cuDNN cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cudnn-library-cache
       with:
         key: v1-cudnn-library-cache-${{ inputs.asset_name }}-${{ inputs.cudnn_download_url }}

--- a/.github/workflows/download_and_deploy.yml
+++ b/.github/workflows/download_and_deploy.yml
@@ -21,12 +21,12 @@ jobs:
         include:
           - os: windows-2022
             artifact_name: windows-x64
-            cudnn_download_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.4.1/local_installers/11.6/cudnn-windows-x86_64-8.4.1.50_cuda11.6-archive.zip
-            cuda_version: 11.6.2
-          - os: ubuntu-20.04
+            cudnn_download_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip
+            cuda_version: 11.8.0
+          - os: ubuntu-22.04
             artifact_name: linux-x64
-            cudnn_download_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.4.1/local_installers/11.6/cudnn-linux-x86_64-8.4.1.50_cuda11.6-archive.tar.xz
-            cuda_version: 11.6.2
+            cudnn_download_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.9.2.26_cuda11-archive.tar.xz
+            cuda_version: 11.8.0
     env:
       ASSET_NAME: CUDA-${{ matrix.artifact_name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/download_and_deploy.yml
+++ b/.github/workflows/download_and_deploy.yml
@@ -31,6 +31,14 @@ jobs:
       ASSET_NAME: CUDA-${{ matrix.artifact_name }}
     runs-on: ${{ matrix.os }}
     steps:
+      # CUDAで容量不足になるので容量削減
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        if: runner.os == 'Linux'
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
       - uses: actions/checkout@v3
       - name: Prepare directory
         shell: bash


### PR DESCRIPTION
## 内容

VOICEVOX/voicevox_engine#709 のため、現状のVOICEVOX [0.23.1](https://github.com/VOICEVOX/voicevox_engine/releases/tag/0.23.1)及び0.24.0（予定）と同じにする。

CUDAとcuDNNだけバージョンアップする。DirectMLはENGINEと同じ1.10.0のままにする。

また`ubuntu-20.04`はもう駄目そうなので`ubuntu-22.04`に引き上げる。
\[追記\] あと #4 と #7 のやつも…。

## 関連 Issue

## スクリーンショット・動画など

## その他
