### PR TITLE
chore: bump actions/cache to `v4`

### DIFF
--- a/.github/actions/download-cuda-libraries/action.yml
+++ b/.github/actions/download-cuda-libraries/action.yml
@@ -17,13 +17,13 @@ runs:
   using: "composite"
   steps:
     - name: Prepare CUDA cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cuda-library-cache
       with:
         key: v1-cuda-library-cache-${{ inputs.asset_name }}-${{ inputs.cuda_version }}
         path: download/cuda
     - name: Prepare cuDNN cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cudnn-library-cache
       with:
         key: v1-cudnn-library-cache-${{ inputs.asset_name }}-${{ inputs.cudnn_download_url }}


### PR DESCRIPTION
## 内容

v2が動かなくなってたため。どうやら今年の2月にbrownoutがあり、3月で完全に使用不可になった模様。

```console
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```

#6 をやってる最中に発覚。

## 関連 Issue

## スクリーンショット・動画など

## その他
