### PR TITLE
chore: [release-0.1] `target_commit`をちゃんと指定

### DIFF
--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -33,4 +33,5 @@ runs:
         repo_token: ${{ inputs.repo_token }}
         prerelease: true
         tag: ${{ inputs.version }}
+        target_commit: ${{ github.sha }}
         file: ${{ inputs.asset_name }}.zip


### PR DESCRIPTION
## 内容

これをやらないと、必ず`main`ブランチ上にリリースが作られてしまう。というかされてしまった。
https://github.com/VOICEVOX/voicevox_additional_libraries/pull/6#issuecomment-2993371543

## 関連 Issue

## スクリーンショット・動画など

## その他
