### PR TITLE
chore: upload-release-actionの`target_commit`をちゃんと指定

### DIFF
--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -33,4 +33,5 @@ runs:
         repo_token: ${{ inputs.repo_token }}
         prerelease: true
         tag: ${{ inputs.version }}
+        target_commit: ${{ github.sha }}
         file: ${{ inputs.asset_name }}.zip


### PR DESCRIPTION
## 内容

これをやらないと、リリースが必ず`main`ブランチ上に作られてしまう。

## 関連 Issue

## スクリーンショット・動画など

## その他
