### PR TITLE
refactor(windows): [release-0.1] state that the zlib is v1.2.3

### DIFF
--- a/.github/workflows/download_and_deploy.yml
+++ b/.github/workflows/download_and_deploy.yml
@@ -26,7 +26,7 @@ jobs:
           path: zlibwapi.dll
       # NOTE: CUDAのcudnnに必要
       # FIXME: ワークアラウンド処理。本当は自分でビルドした方が良い。
-      - name: Download and take zlibwapi.dll
+      - name: Download and take zlibwapi.dll v1.2.3
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           curl -fLO --retry 3 --retry-delay 5 \


### PR DESCRIPTION
## 内容

`zlib-for-windows-cuda-v1.2.3`の`v1.2.3`がzlibwapi.dllのバージョンであるということがぱっとはわからないようになっているので、`key`を指定する箇所の3行下の部分にて明記するようにする。

<https://github.com/VOICEVOX/voicevox_additional_libraries/pull/10#issuecomment-3026250545>

## 関連 Issue

Refs: #10

## スクリーンショット・動画など

## その他
