### PR TITLE
fix(windows,cuda): properly include zlibwapi.dll

### DIFF
--- a/.github/workflows/download_and_deploy.yml
+++ b/.github/workflows/download_and_deploy.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Include zlibwapi.dll
         if: runner.os == 'Windows'
         shell: bash
-        run: mv zlib_for_windows_cuda/zlibwapi.dll artifact/
+        run: mv zlib_for_windows_cuda/zlibwapi.dll "artifact/$ASSET_NAME"
       - name: Upload CUDA
         if: ${{ env.VERSION != 'DEBUG' && env.SKIP_UPLOADING_RELEASE_ASSET == '0' }}
         uses: ./.github/actions/upload-artifact


### PR DESCRIPTION
## 内容

[`0.1.2`](https://github.com/VOICEVOX/voicevox_additional_libraries/releases/tag/0.1.2)の中身を見たらzlibwapiが入ってなかったので。

## 関連 Issue

## スクリーンショット・動画など

## その他
