### PR TITLE
ci: リリースアセットアップロードに contents: write を明示する

### DIFF
--- a/.github/workflows/download_and_deploy.yml
+++ b/.github/workflows/download_and_deploy.yml
@@ -30,6 +30,8 @@ jobs:
     env:
       ASSET_NAME: CUDA-${{ matrix.artifact_name }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     steps:
       # CUDAで容量不足になるので容量削減
       - name: Free Disk Space
@@ -70,6 +72,8 @@ jobs:
     env:
       ASSET_NAME: DirectML-${{ matrix.artifact_name }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - name: Prepare directory


### PR DESCRIPTION
## 内容

GITHUB_TOKEN のデフォルト権限を read-only にする準備として、write が必要な job に permissions を明示します。

- release asset upload を行う CUDA と DirectML の job に `contents: write` を明示します。
- public resource の read 用 permissions は追加していません。

## 関連 Issue

ref VOICEVOX/voicevox_project#93
