### PR TITLE
ci: ワークフロー起動からon: release.publishedを削除

### DIFF
--- a/.github/workflows/download_and_deploy.yml
+++ b/.github/workflows/download_and_deploy.yml
@@ -2,17 +2,14 @@ name: download and deploy
 on:
   push:
   pull_request:
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       version:
         description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
         required: true
 env:
-  # releaseタグ名か、workflow_dispatchでのバージョン名か、DEBUGが入る
-  VERSION: ${{ github.event.release.tag_name || github.event.inputs.version || 'DEBUG' }}
+  # workflow_dispatchでのバージョン名か、DEBUGが入る
+  VERSION: ${{ inputs.version || 'DEBUG' }}
 
 jobs:
   download_and_deploy_cuda:

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ DirectML のバージョンはリリースノートか、「Microsoft.AI.DirectM
 
 ## デプロイ方法
 
-Release を作成するか、`download_and_deploy.yml`を workflow_dispatch で実行します。
+`download_and_deploy.yml`を workflow_dispatch で実行します。


### PR DESCRIPTION
## 内容

ビルドワークフロー `download_and_deploy.yml` をリリース公開時に自動起動する経路を削除するのはどうか、という提案兼 PR です。

デバッグのために便利かなと思っていたのと、昔の名残で残していましたが、コードが煩雑化してしまったり、セキュリティ的にリスクになり得ると思ったので削除しようと思います。
代わりに、GitHub の `Actions` で `workflow_dispatch` すればリリースできます。

VOICEVOX/voicevox#2992、VOICEVOX/voicevox_engine#1854、VOICEVOX/voicevox_core#1262 と同様の対応です。

## 関連 Issue

なし
