### PR TITLE
chore: ONNX Runtime 1.23.2に合わせて依存ライブラリを更新する

### DIFF
--- a/.github/actions/download-cuda-libraries/action.yml
+++ b/.github/actions/download-cuda-libraries/action.yml
@@ -51,7 +51,7 @@ runs:
         mv download/cudnn_tmp/bin/*.{so*,dll} download/cudnn/bin/ || true
         rm -rf download/cudnn_tmp
         rm -f download/cudnn.*
-    - uses: Jimver/cuda-toolkit@d34c721df9930a1f5375dbe0f6e52af57c7f56e1 # v0.2.15
+    - uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
       if: steps.cuda-library-cache.outputs.cache-hit != 'true'
       id: cuda-toolkit
       with:
@@ -85,8 +85,7 @@ runs:
         ln -sf "$(pwd)/download/cuda/bin"/cufft64_*.dll "${{ inputs.extract_dir }}"
         ln -sf "$(pwd)/download/cuda/bin"/curand64_*.dll "${{ inputs.extract_dir }}"
         # cuDNN
-        ln -sf "$(pwd)/download/cudnn/bin"/cudnn64_*.dll "${{ inputs.extract_dir }}"
-        ln -sf "$(pwd)/download/cudnn/bin"/cudnn_*_infer64*.dll "${{ inputs.extract_dir }}"
+        ln -sf "$(pwd)/download/cudnn/bin"/cudnn*.dll "${{ inputs.extract_dir }}"
     - name: Extract Libraries for Linux
       shell: bash
       if: ${{ runner.os == 'Linux' }}
@@ -103,7 +102,5 @@ runs:
         ln -sf "$(pwd)/download/cuda/bin"/libcurand.so.* "${{ inputs.extract_dir }}"
         rm -f "${{ inputs.extract_dir }}"/libcurand.so.*.*
         # cuDNN
-        ln -sf "$(pwd)/download/cudnn/bin"/libcudnn.so.* "${{ inputs.extract_dir }}"
-        rm -f "${{ inputs.extract_dir }}"/libcudnn.so.*.*
-        ln -sf "$(pwd)/download/cudnn/bin"/libcudnn_*_infer.so.* "${{ inputs.extract_dir }}"
-        rm -f "${{ inputs.extract_dir }}"/libcudnn_*_infer.so.*.*
+        ln -sf "$(pwd)/download/cudnn/bin"/libcudnn*.so.* "${{ inputs.extract_dir }}"
+        rm -f "${{ inputs.extract_dir }}"/libcudnn*.so.*.*

--- a/.github/workflows/download_and_deploy.yml
+++ b/.github/workflows/download_and_deploy.yml
@@ -18,12 +18,12 @@ jobs:
         include:
           - os: windows-2022
             artifact_name: windows-x64
-            cudnn_download_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.2.26_cuda12-archive.zip
-            cuda_version: 12.2.2
+            cudnn_download_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-9.8.0.87_cuda12-archive.zip
+            cuda_version: 12.8.1
           - os: ubuntu-22.04
             artifact_name: linux-x64
-            cudnn_download_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
-            cuda_version: 12.2.2
+            cudnn_download_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-9.8.0.87_cuda12-archive.tar.xz
+            cuda_version: 12.8.1
     env:
       ASSET_NAME: CUDA-${{ matrix.artifact_name }}
     runs-on: ${{ matrix.os }}
@@ -65,7 +65,7 @@ jobs:
         include:
           - platform: x64-win
             artifact_name: windows-x64
-            directml_version: 1.13.1
+            directml_version: 1.15.4
     env:
       ASSET_NAME: DirectML-${{ matrix.artifact_name }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 内容

ONNX Runtimeの更新に向けて、配布するCUDA関連ライブラリとDirectMLを更新します。

CUDAとcuDNN、`Jimver/cuda-toolkit`は、[ONNX Runtime Builderの更新](https://github.com/VOICEVOX/onnxruntime-builder/pull/112)に合わせて更新します。
DirectMLは[ONNX Runtimeで指定されているバージョン](https://github.com/microsoft/onnxruntime/blob/v1.23.2/csharp/src/Microsoft.ML.OnnxRuntime.DirectML/packages.config)に合わせて更新します。

cuDNNのメジャーバージョン更新により`*_infer_*`がなくなり、必要なファイルが増えました。
たぶん全部必要なので全部組み込んでいます。
サイズはWindowsで813 MiBから961 MiBに、Linuxで803 MiBから999 MiBになります。

## 関連 Issue

ref https://github.com/VOICEVOX/voicevox_project/issues/99
ref https://github.com/VOICEVOX/onnxruntime-builder/pull/112
